### PR TITLE
Add node requirement to build plan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+on:
+    release:
+        types:
+            - published
+jobs:
+    register:
+        name: Package, Publish, and Register
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - id: checkout
+              name: Checkout code
+              uses: actions/checkout@v2
+            - if: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+              name: Login to GitHub Package Registry
+              uses: docker/login-action@v1
+              with:
+                registry: ghcr.io
+                username: ${{ github.repository_owner }}
+                password: ${{ secrets.GHCR_TOKEN }}
+            - id: setup-pack
+              uses: buildpacks/github-actions/setup-pack@v4.8.0
+            - id: package
+              run: |
+                #!/usr/bin/env bash
+                set -euo pipefail
+                BP_ID="$(cat buildpack.toml | yj -t | jq -r .buildpack.id)"
+                VERSION="$(cat buildpack.toml | yj -t | jq -r .buildpack.version)"
+                PACKAGE="${REPO}/$(echo "$BP_ID" | sed 's/\//_/g')"
+                pack buildpack package --publish ${PACKAGE}:${VERSION}
+                DIGEST="$(crane digest ${PACKAGE}:${VERSION})"
+                echo "::set-output name=bp_id::$BP_ID"
+                echo "::set-output name=version::$VERSION"
+                echo "::set-output name=address::${PACKAGE}@${DIGEST}"
+              shell: bash
+              env:
+                REPO: ghcr.io/${{ github.repository_owner }}/buildpacks
+            - id: register
+              uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.8.0
+              with:
+                token:   ${{ secrets.PUBLIC_REPO_TOKEN }}
+                id:      ${{ steps.package.outputs.bp_id }}
+                version: ${{ steps.package.outputs.version }}
+                address: ${{ steps.package.outputs.address }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # main
 
+## 0.1.1 (2021-03-28)
+### Added
+- Add node requirement to build plan ([#7](https://github.com/heroku/nodejs-yarn-buildpack/pull/7))
+
 ## 0.1.0 (2020-11-11)
 ### Added
 - Add support for heroku-20 and bionic stacks ([#4](https://github.com/heroku/nodejs-yarn-buildpack/pull/4))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # main
 
+## 0.1.2 (2021-07-08)
+### Added
+- Add cache layer for yarn build
+- Allow run build from a specific path
+
 ## 0.1.1 (2021-03-28)
 ### Added
 - Add node requirement to build plan ([#7](https://github.com/heroku/nodejs-yarn-buildpack/pull/7))

--- a/README.md
+++ b/README.md
@@ -9,14 +9,10 @@ This buildpack builds on top of the existing [Node.js Engine Cloud Native Buildp
 
 ## Usage
 
-This buildpack is not meant to be used on its own, and instead should be in used in combination with other buildpacks.
-
-Include a list of `apt` package names to be installed in a file named `Aptfile`; be aware that line ending should be LF, not CRLF.
-
-The buildpack automatically downloads and installs the packages when you run a build:
+This buildpack is meant to be used with `heroku/nodejs-engine` version `0.7.3`.
 
 ```
-$ pack build --buildpack fagiani/nodejs-yarn myapp
+$ pack build --buildpack heroku/nodejs-engine@0.7.3 --buildpack fagiani/nodejs-yarn myapp
 ```
 
 ### Define a custom path for yarn (optional)
@@ -28,64 +24,6 @@ You can optionally create a `yarn.lock` file in the root directory with a line l
 ```
 
 Make sure you place the actual `package.json` and `yarn.lock` in that path
-
-### Build the image
-
-#### with buildpacks
-
-Using pack, you're ready to create an image from the buildpack and source code. You will need to add flags that point to the path of the source code (`--path`) and the paths of the buildpacks (`--buildpack`).
-
-```sh
-cd nodejs-yarn-buildpack
-pack build TEST_IMAGE_NAME --path ../TEST_REPO_PATH --buildpack ../nodejs-engine-buildpack --buildpack ../nodejs-yarn-buildpack
-```
-
-#### with a builder
-
-You can also create a `builder.toml` file that will have explicit directions when creating a buildpack. This is useful when there are multiple "detect" paths a build can take (ie. yarn vs. npm commands).
-
-In a directory outside of this buildpack, create a builder file:
-
-```sh
-cd ..
-mkdir heroku_nodejs_builder
-touch heroku_nodejs_builder/builder.toml
-```
-
-For local development, you'll want the file to look like this:
-
-```toml
-[[buildpacks]]
-  id = "heroku/nodejs-engine-buildpack"
-  uri = "../nodejs-engine-buildpack"
-
-[[buildpacks]]
-  id = "heroku/nodejs-yarn-buildpack"
-  uri = "../nodejs-yarn-buildpack"
-
-[[order]]
-  group = [
-    { id = "heroku/nodejs-engine-buildpack", version = "0.0.1" },
-    { id = "heroku/nodejs-yarn-buildpack", version = "0.0.1" }
-  ]
-
-[stack]
-  id = "heroku-18"
-  build-image = "heroku/pack:18"
-  run-image = "heroku/pack:18"
-```
-
-Create the builder with `pack`:
-
-```sh
-pack create-builder nodejs --builder-config ../heroku-nodejs-builder/builder.toml
-```
-
-Now you can use the builder image instead of chaining the buildpacks.
-
-```sh
-pack build TEST_IMAGE_NAME --path ../TEST_REPO_PATH --builder nodejs
-```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ cd .. # change from nodejs-npm-buildpack directory
 git clone git@github.com:heroku/nodejs-engine-buildpack.git
 ```
 
+### Define a custom path for yarn (optional)
+
+You can optionally create a `yarn.lock` file in the root directory with a line like this:
+
+```
+# yarn_path:public/my-custom-path
+```
+
+Make sure you place the actual `package.json` and `yarn.lock` in that path
+
 ### Build the image
 
 #### with buildpacks

--- a/README.md
+++ b/README.md
@@ -9,30 +9,14 @@ This buildpack builds on top of the existing [Node.js Engine Cloud Native Buildp
 
 ## Usage
 
-### Install pack
+This buildpack is not meant to be used on its own, and instead should be in used in combination with other buildpacks.
 
-Using `brew` (assuming development is done on MacOS), install `pack`.
+Include a list of `apt` package names to be installed in a file named `Aptfile`; be aware that line ending should be LF, not CRLF.
 
-```sh
-brew tap buildpack/tap
-brew install pack
+The buildpack automatically downloads and installs the packages when you run a build:
+
 ```
-
-If you're using Windows or Linux, follow instructions [here](https://buildpacks.io/docs/install-pack/).
-
-### Clone the buildpack
-
-Right now, we are prototyping with a local version of the buildpack. Clone it to your machine.
-
-```sh
-git clone git@github.com:heroku/nodejs-yarn-buildpack.git
-```
-
-Clone the Heroku Node.js Engine Cloud Native Buildpack.
-
-```sh
-cd .. # change from nodejs-npm-buildpack directory
-git clone git@github.com:heroku/nodejs-engine-buildpack.git
+$ pack build --buildpack fagiani/nodejs-yarn myapp
 ```
 
 ### Define a custom path for yarn (optional)

--- a/bin/build
+++ b/bin/build
@@ -9,10 +9,14 @@ platform_dir=$2
 
 # shellcheck source=/dev/null
 source "$bp_dir/lib/build.sh"
+# shellcheck source=/dev/null
+source "$bp_dir/lib/utils/yarn.sh"
 rm -rf "$build_dir/node_modules"
+
+build_dir=$(extract_path_from_yarn_lock "$build_dir")
 
 export_env "$platform_dir/env" "" ""
 run_prebuild "$build_dir"
 install_or_reuse_node_modules "$build_dir" "$layers_dir/node_modules"
-run_build "$build_dir"
+run_build "$build_dir" "$layers_dir"
 write_launch_toml "$build_dir/package.json" "$layers_dir/launch.toml"

--- a/bin/detect
+++ b/bin/detect
@@ -4,10 +4,13 @@ set -eo pipefail
 
 bp_dir=$(cd "$(dirname "$0")"/..; pwd)
 build_dir=$(pwd)
+build_plan="$2"
 
 # shellcheck source=/dev/null
 source "$bp_dir/lib/detect.sh"
 
 if ! detect_yarn_lock "$build_dir" ; then
   exit 100
+else
+  write_to_build_plan "$build_plan"
 fi

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.4"
 
 [buildpack]
 id = "fagiani/nodejs-yarn"
-version = "0.2.0"
+version = "0.2.1"
 name = "Yarn Buildpack"
 homepage = "https://github.com/fagiani/nodejs-yarn-buildpack"
 description = "Runs Yarn after nodejs install"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,8 +1,8 @@
 api = "0.2"
 
 [buildpack]
-id = "heroku/nodejs-yarn"
-version = "0.1.0"
+id = "fagiani/nodejs-yarn"
+version = "0.1.2"
 name = "Yarn Buildpack"
 
 [[stacks]]

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,9 +1,15 @@
-api = "0.2"
+api = "0.4"
 
 [buildpack]
 id = "fagiani/nodejs-yarn"
-version = "0.1.2"
+version = "0.2.0"
 name = "Yarn Buildpack"
+homepage = "https://github.com/fagiani/nodejs-yarn-buildpack"
+description = "Runs Yarn after nodejs install"
+keywords = ["nodejs", "node", "yarn", "install", "javascript"]
+
+[[buildpack.licenses]]
+type = "MIT"
 
 [[stacks]]
 id = "heroku-18"

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -19,7 +19,7 @@ run_prebuild() {
   heroku_prebuild_script=$(json_get_key "$build_dir/package.json" ".scripts[\"heroku-prebuild\"]")
 
   if [[ $heroku_prebuild_script ]] ; then
-    cd $build_dir
+    cd "$build_dir"
     yarn heroku-prebuild
     cd -
   fi
@@ -28,7 +28,7 @@ run_prebuild() {
 install_modules() {
   local build_dir=$1
 
-  cd $build_dir
+  cd "$build_dir"
   if detect_yarn_lock "$build_dir" ; then
     echo "---> Installing node modules from $build_dir/yarn.lock"
     yarn install
@@ -89,13 +89,13 @@ TOML
     mkdir -p "${layer_dir}"
     cp -r "$layer_dir" "$build_dir/$build_cache"
     echo "$build_dir/$build_cache"
-    ls -lsa $build_dir/$build_cache
+    ls -lsa "$build_dir/$build_cache"
   fi
 
   build_script=$(json_get_key "$build_dir/package.json" ".scripts.build")
   heroku_postbuild_script=$(json_get_key "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")
 
-  cd $build_dir
+  cd "$build_dir"
   if [[ $heroku_postbuild_script ]] ; then
     yarn heroku-postbuild
   elif [[ $build_script ]] ; then
@@ -104,8 +104,8 @@ TOML
   cd -
 
   echo "$build_dir/$build_cache"
-  ls -lsa $build_dir/$build_cache
-  ls -lsa $build_dir/resources/assets/build
+  ls -lsa "$build_dir/$build_cache"
+  ls -lsa "$build_dir/resources/assets/build"
 
   if [[ $build_cache && -d "$build_dir/$build_cache" && -n "$(ls -A "$build_dir/$build_cache")" ]] ; then
     cp -r "$build_dir/$build_cache/." "$layer_dir"

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -19,20 +19,24 @@ run_prebuild() {
   heroku_prebuild_script=$(json_get_key "$build_dir/package.json" ".scripts[\"heroku-prebuild\"]")
 
   if [[ $heroku_prebuild_script ]] ; then
+    cd $build_dir
     yarn heroku-prebuild
+    cd -
   fi
 }
 
 install_modules() {
   local build_dir=$1
 
+  cd $build_dir
   if detect_yarn_lock "$build_dir" ; then
-    echo "---> Installing node modules from ./yarn.lock"
+    echo "---> Installing node modules from $build_dir/yarn.lock"
     yarn install
   else
     echo "---> Installing node modules"
     yarn install --no-lockfile
   fi
+  cd -
 }
 
 install_or_reuse_node_modules() {
@@ -69,16 +73,42 @@ install_or_reuse_node_modules() {
 
 run_build() {
   local build_dir=$1
+  local layer_dir=$2
+  local build_cache
   local build_script
   local heroku_postbuild_script
+
+  build_cache=$(json_get_key "$build_dir/package.json" ".directories[\"heroku-buildcache\"]")
+  if [[ $build_cache ]] ; then
+    layer_dir="$layer_dir/$build_cache"
+    cat <<TOML > "$layer_dir.toml"
+cache = true
+build = false
+launch = false
+TOML
+    mkdir -p "${layer_dir}"
+    cp -r "$layer_dir" "$build_dir/$build_cache"
+    echo "$build_dir/$build_cache"
+    ls -lsa $build_dir/$build_cache
+  fi
 
   build_script=$(json_get_key "$build_dir/package.json" ".scripts.build")
   heroku_postbuild_script=$(json_get_key "$build_dir/package.json" ".scripts[\"heroku-postbuild\"]")
 
+  cd $build_dir
   if [[ $heroku_postbuild_script ]] ; then
     yarn heroku-postbuild
   elif [[ $build_script ]] ; then
     yarn build
+  fi
+  cd -
+
+  echo "$build_dir/$build_cache"
+  ls -lsa $build_dir/$build_cache
+  ls -lsa $build_dir/resources/assets/build
+
+  if [[ $build_cache && -d "$build_dir/$build_cache" && -n "$(ls -A "$build_dir/$build_cache")" ]] ; then
+    cp -r "$build_dir/$build_cache/." "$layer_dir"
   fi
 }
 
@@ -93,5 +123,4 @@ type = "web"
 command = "yarn start"
 TOML
   fi
-
 }

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -103,10 +103,6 @@ TOML
   fi
   cd -
 
-  echo "$build_dir/$build_cache"
-  ls -lsa "$build_dir/$build_cache"
-  ls -lsa "$build_dir/resources/assets/build"
-
   if [[ $build_cache && -d "$build_dir/$build_cache" && -n "$(ls -A "$build_dir/$build_cache")" ]] ; then
     cp -r "$build_dir/$build_cache/." "$layer_dir"
   fi

--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -4,3 +4,11 @@ detect_yarn_lock() {
   local build_dir=$1
   [[ -f "$build_dir/yarn.lock" ]]
 }
+
+write_to_build_plan() {
+  local build_plan=$1
+  cat << EOF > "$build_plan"
+  [[requires]]
+  name = "node"
+EOF
+}

--- a/lib/utils/yarn.sh
+++ b/lib/utils/yarn.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+extract_path_from_yarn_lock() {
+  local build_dir=$1
+
+  if grep -q -e "^# :yarn_path:" $build_dir/yarn.lock; then
+    echo "$1/$(cat $build_dir/yarn.lock | grep -s -e "^# :yarn_path:" | sed 's/^# :yarn_path:\(.*\)\s*$/\1/g')"
+  else
+    echo "$1"
+  fi
+}

--- a/lib/utils/yarn.sh
+++ b/lib/utils/yarn.sh
@@ -3,8 +3,8 @@
 extract_path_from_yarn_lock() {
   local build_dir=$1
 
-  if grep -q -e "^# :yarn_path:" $build_dir/yarn.lock; then
-    echo "$1/$(cat $build_dir/yarn.lock | grep -s -e "^# :yarn_path:" | sed 's/^# :yarn_path:\(.*\)\s*$/\1/g')"
+  if grep -q -e "^# :yarn_path:" "$build_dir/yarn.lock"; then
+    echo "$1/$(grep -s -e "^# :yarn_path:" "$build_dir/yarn.lock" | sed 's/^# :yarn_path:\(.*\)\s*$/\1/g')"
   else
     echo "$1"
   fi

--- a/package.toml
+++ b/package.toml
@@ -1,0 +1,5 @@
+[buildpack]
+uri = "."
+
+[[dependencies]]
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-engine-buildpack@sha256:4fa85f23b1df1138039ec6f5667da48da2af7858767b8840a754c54b39b42ca1"


### PR DESCRIPTION
# Description

This change aims to fix the detection phase of the buildpack as it should require `node` in order to fulfill the need to add the `heroku/nodejs-engine` buildpack.

Fixes #6 

# Checklist:

- [x] Run these changes with `pack`
- [x] Make updates to `CHANGELOG.md`
